### PR TITLE
Confirm printful order.

### DIFF
--- a/app/services/printful/create_order.rb
+++ b/app/services/printful/create_order.rb
@@ -26,7 +26,8 @@ module Printful
           state_code: order.address.state_code,
           country_code: order.address.country_code,
         },
-        items: order.line_items.map { |item| line_item_payload(item) }
+        items: order.line_items.map { |item| line_item_payload(item) },
+        confirm: Rails.configuration.printful[:confirm_order]
       }
     end
 

--- a/config/initializers/printful.rb
+++ b/config/initializers/printful.rb
@@ -1,1 +1,7 @@
 PrintfulAPI.api_key = Rails.application.credentials.printful_api_key
+
+Rails.application.configure do
+  config.printful = {
+    confirm_order: !!ENV["PRINTFUL_CONFIRM_ORDER"]
+  }
+end


### PR DESCRIPTION
Add confirm key to printful payload.
By default, orders will be saved as draft and have to be confirmed before they will be fulfilled by printful. By setting `ENV["PRINTFUL_CONFIRM_ORDER"]` to true, submitted orders will be automatically confirmed.