### PR TITLE
Add frozen string literal magic comment to all files in app folder.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,7 @@ group :development, :test do
   gem 'factory_bot_rails'
   gem 'faker'
   gem 'dotenv-rails'
+  gem 'rubocop', require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,7 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
+    ast (2.4.0)
     autoprefixer-rails (9.4.4)
       execjs
     barnes (0.0.7)
@@ -107,6 +108,7 @@ GEM
       domain_name (~> 0.5)
     i18n (1.4.0)
       concurrent-ruby (~> 1.0)
+    jaro_winkler (1.5.2)
     jbuilder (2.8.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
@@ -149,8 +151,12 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.10.0)
       mini_portile2 (~> 2.4.0)
+    parallel (1.12.1)
+    parser (2.5.3.0)
+      ast (~> 2.4.0)
     pg (1.1.3)
     popper_js (1.14.5)
+    powerpack (0.1.2)
     premailer (1.11.1)
       addressable
       css_parser (>= 1.6.0)
@@ -192,6 +198,7 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
+    rainbow (3.0.0)
     rake (12.3.2)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
@@ -221,6 +228,15 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
+    rubocop (0.62.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.5, != 2.5.1.1)
+      powerpack (~> 0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.4.0)
+    ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
     sass (3.7.3)
       sass-listen (~> 4.0.0)
@@ -276,6 +292,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
+    unicode-display_width (1.4.1)
     web-console (3.7.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -318,6 +335,7 @@ DEPENDENCIES
   rmagick
   rollbar
   rspec-rails
+  rubocop
   sass-rails (~> 5.0)
   select2-rails
   simple_form

--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ApplicationCable
   class Channel < ActionCable::Channel::Base
   end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationController < ActionController::Base
   helper_method :cart
 

--- a/app/controllers/cart_controller.rb
+++ b/app/controllers/cart_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CartController < ApplicationController
   def add
     product = Product.first

--- a/app/controllers/countries_controller.rb
+++ b/app/controllers/countries_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CountriesController < ApplicationController
   def states
     country_code = params[:country_code]

--- a/app/controllers/designs_controller.rb
+++ b/app/controllers/designs_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class DesignsController < ApplicationController
   def new
   end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ImagesController < ApplicationController
   before_action :cache_response
 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class OrdersController < ApplicationController
   before_action :noindex
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ApplicationHelper
   def canonical_url
     config = Rails.application.config.canonical

--- a/app/helpers/countries_helper.rb
+++ b/app/helpers/countries_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module CountriesHelper
   def country_options_for_select(selected: nil)
     options_for_select(Countries.list.invert, selected&.upcase)

--- a/app/helpers/designs_helper.rb
+++ b/app/helpers/designs_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DesignsHelper
   def color_options_for_select(product, variant)
     available_colors = product.variants.pluck(:color).uniq

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ProductsHelper
   def html_description(product)
     markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML.new)

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class ApplicationJob < ActiveJob::Base
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationMailer < ActionMailer::Base
   default from: 'noreply@supermeme.co'
   layout 'mailer'

--- a/app/mailers/order_mailer.rb
+++ b/app/mailers/order_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class OrderMailer < ApplicationMailer
   default from: 'orders@supermeme.co'
 

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Address < ApplicationRecord
   has_one :purchase_order
 

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 end

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class LineItem < ApplicationRecord
   belongs_to :purchase_order
   belongs_to :variant

--- a/app/models/printfile.rb
+++ b/app/models/printfile.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Printfile < ApplicationRecord
   validates :width, presence: true
   validates :height, presence: true

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Product < ApplicationRecord
   has_many :variants
 

--- a/app/models/purchase_order.rb
+++ b/app/models/purchase_order.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PurchaseOrder < ApplicationRecord
   belongs_to :address, dependent: :destroy
   has_many :line_items, dependent: :destroy

--- a/app/models/variant.rb
+++ b/app/models/variant.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Variant < ApplicationRecord
   belongs_to :product
   belongs_to :printfile

--- a/app/services/countries.rb
+++ b/app/services/countries.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 class Countries
   include Singleton

--- a/app/services/designs/supreme.rb
+++ b/app/services/designs/supreme.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Designs
   class Supreme
     def self.call(text, variant)

--- a/app/services/generators/supreme.rb
+++ b/app/services/generators/supreme.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Generators
   class Supreme
     BASE_SIZE = 720

--- a/app/services/mockups/t_shirt.rb
+++ b/app/services/mockups/t_shirt.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Mockups
   class TShirt
     COLOR_CONFIG = {

--- a/app/services/printful/base.rb
+++ b/app/services/printful/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Printful
   class Base
     attr_reader :order

--- a/app/services/printful/create_order.rb
+++ b/app/services/printful/create_order.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Printful
   class CreateOrder < Base
     def call(confirm: false)

--- a/app/services/printful/update_order.rb
+++ b/app/services/printful/update_order.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Printful
   class UpdateOrder < Base
     def call(confirm: false)

--- a/app/services/printful/validate_order.rb
+++ b/app/services/printful/validate_order.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Printful
   class ValidateOrder < Base
     def call

--- a/app/services/stripe/create_charge.rb
+++ b/app/services/stripe/create_charge.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Stripe
   class CreateCharge
     attr_reader :order


### PR DESCRIPTION
Add frozen string literal magic comment.
This should reduce the number of allocated objects and result to less memory usage.