### PR TITLE
Add rack timeout.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ gem 'meta-tags'
 gem 'newrelic_rpm'
 gem 'rollbar'
 gem 'barnes'
+gem 'rack-timeout'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,6 +170,7 @@ GEM
     rack (2.0.6)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
+    rack-timeout (0.5.1)
     rails (5.2.2)
       actioncable (= 5.2.2)
       actionmailer (= 5.2.2)
@@ -328,6 +329,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   printful_api
   puma (~> 3.11)
+  rack-timeout
   rails (~> 5.2.1)
   rails-controller-testing
   redcarpet


### PR DESCRIPTION
Timeout requests in the app before reaching heroku timeout.