### PR TITLE
Destroy images after use.

### DIFF
--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -18,6 +18,8 @@ class ImagesController < ApplicationController
     image = generator.call(CGI::unescape(text), size: size.to_i)
 
     send_data image.to_blob, type: image.mime_type, disposition: 'inline'
+  ensure
+    image && image.destroy!
   end
 
   def product_variant
@@ -31,6 +33,8 @@ class ImagesController < ApplicationController
     design = designer.call(CGI::unescape(text), variant)
 
     send_data design.to_blob, type: design.mime_type, disposition: 'inline'
+  ensure
+    design && design.destroy!
   end
 
   def mockup
@@ -49,6 +53,9 @@ class ImagesController < ApplicationController
     mockup = mockup_generator.call(design, max_width: width)
 
     send_data mockup.to_blob, type: mockup.mime_type, disposition: 'inline'
+  ensure
+    design && design.destroy!
+    mockup && mockup.destroy!
   end
 
   private

--- a/app/services/designs/supreme.rb
+++ b/app/services/designs/supreme.rb
@@ -25,6 +25,8 @@ module Designs
       # place design on canvas
       offset_y = canvas_height * -0.25
       canvas.composite!(design, Magick::CenterGravity, 0, offset_y, Magick::OverCompositeOp)
+    ensure
+      design && design.destroy!
     end
 
     def self.generator

--- a/app/services/mockups/t_shirt.rb
+++ b/app/services/mockups/t_shirt.rb
@@ -39,10 +39,12 @@ module Mockups
       resized_design.rotate!(@rotation) unless @rotation.zero?
 
       product.composite!(resized_design, Magick::CenterGravity, @offset_x, @offset_y, Magick::OverCompositeOp)
-      resized_design.destroy!
 
       product.resize_to_fit!(max_width, max_height) unless max_width == 1200 && max_height == 1200
       product.sharpen(0)
+    ensure
+      resized_design && resized_design.destroy!
+      product && product.destroy!
     end
   end
 end


### PR DESCRIPTION
Undestroyed images resulted in very large memory usage. Manually destroy images once we don't need them anymore.