### PR TITLE
Force garbage collection.

### DIFF
--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -2,6 +2,7 @@
 
 class ImagesController < ApplicationController
   before_action :cache_response
+  after_action :force_gc
 
   DESIGNS = {
     supreme: Designs::Supreme
@@ -62,5 +63,12 @@ class ImagesController < ApplicationController
 
   def cache_response
     fresh_when(last_modified: LAST_DEPLOY, public: true)
+  end
+
+  def force_gc
+    if ObjectSpace.each_object(Magick::Image).count > 100
+      logger.debug "Forcing Garbage Collection"
+      ObjectSpace.garbage_collect
+    end
   end
 end


### PR DESCRIPTION
Force Garbage Collection if there are more than 100 images in memory.
Ideally, we would not have to do this and we could tweak GC parameters.
Also, we could try changing 100 to other values and see how that affects memory usage and performance.