### PR TITLE
Decouple models from printful

### DIFF
--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -27,11 +27,11 @@ class ImagesController < ApplicationController
     designer = DESIGNS.fetch(params["design"].to_sym, nil)
     return head 404 unless designer
 
-    variant_id = params.fetch("variant_id")
+    printfile_id = params.fetch("printfile_id")
     text = params.fetch("text", "Supermeme")
 
-    variant = Variant.find(variant_id)
-    design = designer.call(CGI::unescape(text), variant)
+    printfile = Printfile.find(printfile_id)
+    design = designer.call(CGI::unescape(text), printfile)
 
     send_data design.to_blob, type: design.mime_type, disposition: 'inline'
   ensure
@@ -47,10 +47,11 @@ class ImagesController < ApplicationController
 
     product = Product.first
     variant = product.variants.where(color: color).first || product.variants.first
+    printfile = variant.fulfiller_variants.first.printfile
     mockup_generator = Mockups::TShirt.new(color: variant.color)
 
     text = params.fetch("text", "Supermeme")
-    design = designer.call(CGI::unescape(text), variant)
+    design = designer.call(CGI::unescape(text), printfile)
     mockup = mockup_generator.call(design, max_width: width)
 
     send_data mockup.to_blob, type: mockup.mime_type, disposition: 'inline'

--- a/app/models/fulfiller.rb
+++ b/app/models/fulfiller.rb
@@ -1,2 +1,5 @@
 class Fulfiller < ApplicationRecord
+  def self.printful
+    find_by(name: 'Printful')
+  end
 end

--- a/app/models/fulfiller.rb
+++ b/app/models/fulfiller.rb
@@ -1,0 +1,2 @@
+class Fulfiller < ApplicationRecord
+end

--- a/app/models/fulfiller_product.rb
+++ b/app/models/fulfiller_product.rb
@@ -1,0 +1,7 @@
+class FulfillerProduct < ApplicationRecord
+  belongs_to :fulfiller
+  belongs_to :product
+
+  validates :external_id, presence: true
+  validates :external_id, uniqueness: { scope: :fulfiller_id }
+end

--- a/app/models/fulfiller_variant.rb
+++ b/app/models/fulfiller_variant.rb
@@ -1,0 +1,8 @@
+class FulfillerVariant < ApplicationRecord
+  belongs_to :fulfiller
+  belongs_to :variant
+  belongs_to :printfile
+
+  validates :external_id, presence: true
+  validates :external_id, uniqueness: { scope: :fulfiller_id }
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -5,7 +5,6 @@ class Product < ApplicationRecord
   has_many :fulfillers, through: :fulfiller_products
   has_many :variants
 
-  validates :external_id, presence: true
   validates :title, presence: true
   validates :description, presence: true
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Product < ApplicationRecord
+  has_many :fulfiller_products, dependent: :destroy
+  has_many :fulfillers, through: :fulfiller_products
   has_many :variants
 
   validates :external_id, presence: true

--- a/app/models/variant.rb
+++ b/app/models/variant.rb
@@ -4,7 +4,6 @@ class Variant < ApplicationRecord
   has_many :fulfiller_variants, dependent: :destroy
   has_many :fulfillers, through: :fulfiller_variants
   belongs_to :product
-  belongs_to :printfile
 
   validates :color, presence: true
   validates :size, presence: true

--- a/app/models/variant.rb
+++ b/app/models/variant.rb
@@ -6,7 +6,6 @@ class Variant < ApplicationRecord
   belongs_to :product
   belongs_to :printfile
 
-  validates :external_id, presence: true
   validates :color, presence: true
   validates :size, presence: true
   validates :price, presence: true, numericality: { greater_than_or_equal_to: 0 }

--- a/app/models/variant.rb
+++ b/app/models/variant.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Variant < ApplicationRecord
+  has_many :fulfiller_variants, dependent: :destroy
+  has_many :fulfillers, through: :fulfiller_variants
   belongs_to :product
   belongs_to :printfile
 

--- a/app/services/designs/supreme.rb
+++ b/app/services/designs/supreme.rb
@@ -2,10 +2,10 @@
 
 module Designs
   class Supreme
-    def self.call(text, variant)
+    def self.call(text, printfile)
       # get dimensions of printfile
-      canvas_width = variant.printfile.width
-      canvas_height = variant.printfile.height
+      canvas_width = printfile.width
+      canvas_height = printfile.height
 
       canvas = Magick::Image.new(canvas_width, canvas_height) do |image|
         image.background_color = 'Transparent'

--- a/app/services/printful/base.rb
+++ b/app/services/printful/base.rb
@@ -29,9 +29,11 @@ module Printful
       }.tap { |h| h.merge!(external_id: external_id(order)) if include_id }
     end
 
+    protected
+
     def line_item_payload(item, include_id: true)
       {
-        variant_id: item.variant.external_id,
+        variant_id: printful_id(item.variant),
         quantity: item.quantity,
         retail_price: item.unit_price,
         name: item.title,
@@ -43,6 +45,10 @@ module Printful
 
     def external_id(model)
       Rails.env.development? ? "#{model.id}_dev" : model.id
+    end
+
+    def printful_id(variant)
+      variant.fulfiller_variants.find_by!(fulfiller: Fulfiller.printful).external_id
     end
   end
 end

--- a/app/services/printful/base.rb
+++ b/app/services/printful/base.rb
@@ -33,12 +33,12 @@ module Printful
 
     def line_item_payload(item, include_id: true)
       {
-        variant_id: printful_id(item.variant),
+        variant_id: printful_variant(item.variant).external_id,
         quantity: item.quantity,
         retail_price: item.unit_price,
         name: item.title,
         files: [{
-          url: Rails.application.routes.url_helpers.product_variant_image_url(variant_id: item.variant_id, text: item.text)
+          url: printfile_url(item)
         }]
       }.tap { |h| h.merge!(external_id: external_id(item)) if include_id }
     end
@@ -47,8 +47,12 @@ module Printful
       Rails.env.development? ? "#{model.id}_dev" : model.id
     end
 
-    def printful_id(variant)
-      variant.fulfiller_variants.find_by!(fulfiller: Fulfiller.printful).external_id
+    def printful_variant(variant)
+      variant.fulfiller_variants.find_by!(fulfiller: Fulfiller.printful)
+    end
+
+    def printfile_url(item)
+      Rails.application.routes.url_helpers.printfile_image_url(printfile_id: printful_variant(item.variant).printfile_id, text: item.text)
     end
   end
 end

--- a/app/services/printful/base.rb
+++ b/app/services/printful/base.rb
@@ -44,7 +44,8 @@ module Printful
     end
 
     def external_id(model)
-      Rails.env.development? ? "#{model.id}_dev" : model.id
+      suffix = Rails.application.config.printful[:external_id_suffix]
+      suffix ? "#{model.id}_#{suffix}" : model.id
     end
 
     def printful_variant(variant)

--- a/config/initializers/printful.rb
+++ b/config/initializers/printful.rb
@@ -2,6 +2,7 @@ PrintfulAPI.api_key = ENV.fetch("PRINTFUL_API_KEY")
 
 Rails.application.configure do
   config.printful = {
-    confirm_order: !!ENV["PRINTFUL_CONFIRM_ORDER"]
+    confirm_order: !!ENV["PRINTFUL_CONFIRM_ORDER"],
+    external_id_suffix: ENV["PRINTFUL_EXTERNAL_ID_SUFFIX"]
   }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   resource :design, only: [:new, :create, :show]
 
   get 'images/mockups/t-shirt/:color/*text.:format', to: 'images#mockup', as: :mockup_image, defaults: { design: 'supreme', color: 'black', format: 'jpg' }
-  get 'images/printfiles/:variant_id/:design/*text.:format', to: 'images#product_variant', as: :product_variant_image, defaults: { design: 'supreme', format: 'png' }
+  get 'images/printfiles/:printfile_id/:design/*text.:format', to: 'images#printfile', as: :printfile_image, defaults: { design: 'supreme', format: 'png' }
   get 'images/:design(/x:size)/*text.:format', to: 'images#show', as: :generated_image, defaults: { design: 'supreme', format: 'png' }
 
   get 'cart', to: 'cart#show'

--- a/db/migrate/20190112033554_create_fulfillers.rb
+++ b/db/migrate/20190112033554_create_fulfillers.rb
@@ -1,0 +1,9 @@
+class CreateFulfillers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :fulfillers do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190112034219_create_fulfiller_products.rb
+++ b/db/migrate/20190112034219_create_fulfiller_products.rb
@@ -8,5 +8,6 @@ class CreateFulfillerProducts < ActiveRecord::Migration[5.2]
       t.timestamps
     end
     add_index :fulfiller_products, [:fulfiller_id, :external_id], unique: true
+    add_index :fulfiller_products, [:fulfiller_id, :product_id], unique: true
   end
 end

--- a/db/migrate/20190112034219_create_fulfiller_products.rb
+++ b/db/migrate/20190112034219_create_fulfiller_products.rb
@@ -1,0 +1,12 @@
+class CreateFulfillerProducts < ActiveRecord::Migration[5.2]
+  def change
+    create_table :fulfiller_products do |t|
+      t.references :fulfiller, foreign_key: true
+      t.references :product, foreign_key: true
+      t.integer :external_id
+
+      t.timestamps
+    end
+    add_index :fulfiller_products, [:fulfiller_id, :external_id], unique: true
+  end
+end

--- a/db/migrate/20190112035508_remove_external_id_from_products.rb
+++ b/db/migrate/20190112035508_remove_external_id_from_products.rb
@@ -1,0 +1,5 @@
+class RemoveExternalIdFromProducts < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :products, :external_id
+  end
+end

--- a/db/migrate/20190112035508_remove_external_id_from_products.rb
+++ b/db/migrate/20190112035508_remove_external_id_from_products.rb
@@ -1,5 +1,5 @@
 class RemoveExternalIdFromProducts < ActiveRecord::Migration[5.2]
   def change
-    remove_column :products, :external_id
+    remove_column :products, :external_id, :integer
   end
 end

--- a/db/migrate/20190112044911_create_fulfiller_variants.rb
+++ b/db/migrate/20190112044911_create_fulfiller_variants.rb
@@ -1,0 +1,14 @@
+class CreateFulfillerVariants < ActiveRecord::Migration[5.2]
+  def change
+    create_table :fulfiller_variants do |t|
+      t.references :fulfiller, foreign_key: true
+      t.references :variant, foreign_key: true
+      t.references :printfile, foreign_key: true
+      t.integer :external_id
+
+      t.timestamps
+    end
+    add_index :fulfiller_variants, [:fulfiller_id, :external_id], unique: true
+    add_index :fulfiller_variants, [:fulfiller_id, :variant_id], unique: true
+  end
+end

--- a/db/migrate/20190112050108_remove_external_id_from_variants.rb
+++ b/db/migrate/20190112050108_remove_external_id_from_variants.rb
@@ -1,0 +1,5 @@
+class RemoveExternalIdFromVariants < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :variants, :external_id, :integer
+  end
+end

--- a/db/migrate/20190112050914_remove_printfiles_from_variants.rb
+++ b/db/migrate/20190112050914_remove_printfiles_from_variants.rb
@@ -1,0 +1,5 @@
+class RemovePrintfilesFromVariants < ActiveRecord::Migration[5.2]
+  def change
+    remove_reference :variants, :printfile
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_12_035508) do
+ActiveRecord::Schema.define(version: 2019_01_12_044911) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,8 +33,23 @@ ActiveRecord::Schema.define(version: 2019_01_12_035508) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["fulfiller_id", "external_id"], name: "index_fulfiller_products_on_fulfiller_id_and_external_id", unique: true
+    t.index ["fulfiller_id", "product_id"], name: "index_fulfiller_products_on_fulfiller_id_and_product_id", unique: true
     t.index ["fulfiller_id"], name: "index_fulfiller_products_on_fulfiller_id"
     t.index ["product_id"], name: "index_fulfiller_products_on_product_id"
+  end
+
+  create_table "fulfiller_variants", force: :cascade do |t|
+    t.bigint "fulfiller_id"
+    t.bigint "variant_id"
+    t.bigint "printfile_id"
+    t.integer "external_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["fulfiller_id", "external_id"], name: "index_fulfiller_variants_on_fulfiller_id_and_external_id", unique: true
+    t.index ["fulfiller_id", "variant_id"], name: "index_fulfiller_variants_on_fulfiller_id_and_variant_id", unique: true
+    t.index ["fulfiller_id"], name: "index_fulfiller_variants_on_fulfiller_id"
+    t.index ["printfile_id"], name: "index_fulfiller_variants_on_printfile_id"
+    t.index ["variant_id"], name: "index_fulfiller_variants_on_variant_id"
   end
 
   create_table "fulfillers", force: :cascade do |t|
@@ -99,6 +114,9 @@ ActiveRecord::Schema.define(version: 2019_01_12_035508) do
 
   add_foreign_key "fulfiller_products", "fulfillers"
   add_foreign_key "fulfiller_products", "products"
+  add_foreign_key "fulfiller_variants", "fulfillers"
+  add_foreign_key "fulfiller_variants", "printfiles"
+  add_foreign_key "fulfiller_variants", "variants"
   add_foreign_key "line_items", "purchase_orders"
   add_foreign_key "line_items", "variants"
   add_foreign_key "purchase_orders", "addresses"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_12_050108) do
+ActiveRecord::Schema.define(version: 2019_01_12_050914) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -105,8 +105,6 @@ ActiveRecord::Schema.define(version: 2019_01_12_050108) do
     t.decimal "price"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "printfile_id"
-    t.index ["printfile_id"], name: "index_variants_on_printfile_id"
     t.index ["product_id"], name: "index_variants_on_product_id"
   end
 
@@ -118,6 +116,5 @@ ActiveRecord::Schema.define(version: 2019_01_12_050108) do
   add_foreign_key "line_items", "purchase_orders"
   add_foreign_key "line_items", "variants"
   add_foreign_key "purchase_orders", "addresses"
-  add_foreign_key "variants", "printfiles"
   add_foreign_key "variants", "products"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_21_065010) do
+ActiveRecord::Schema.define(version: 2019_01_12_033554) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,12 @@ ActiveRecord::Schema.define(version: 2018_12_21_065010) do
     t.string "state_code"
     t.string "zip_code"
     t.string "country_code"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "fulfillers", force: :cascade do |t|
+    t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_12_033554) do
+ActiveRecord::Schema.define(version: 2019_01_12_034219) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,17 @@ ActiveRecord::Schema.define(version: 2019_01_12_033554) do
     t.string "country_code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "fulfiller_products", force: :cascade do |t|
+    t.bigint "fulfiller_id"
+    t.bigint "product_id"
+    t.integer "external_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["fulfiller_id", "external_id"], name: "index_fulfiller_products_on_fulfiller_id_and_external_id", unique: true
+    t.index ["fulfiller_id"], name: "index_fulfiller_products_on_fulfiller_id"
+    t.index ["product_id"], name: "index_fulfiller_products_on_product_id"
   end
 
   create_table "fulfillers", force: :cascade do |t|
@@ -88,6 +99,8 @@ ActiveRecord::Schema.define(version: 2019_01_12_033554) do
     t.index ["product_id"], name: "index_variants_on_product_id"
   end
 
+  add_foreign_key "fulfiller_products", "fulfillers"
+  add_foreign_key "fulfiller_products", "products"
   add_foreign_key "line_items", "purchase_orders"
   add_foreign_key "line_items", "variants"
   add_foreign_key "purchase_orders", "addresses"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_12_044911) do
+ActiveRecord::Schema.define(version: 2019_01_12_050108) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -99,7 +99,6 @@ ActiveRecord::Schema.define(version: 2019_01_12_044911) do
   end
 
   create_table "variants", force: :cascade do |t|
-    t.integer "external_id"
     t.bigint "product_id"
     t.string "color"
     t.string "size"
@@ -107,7 +106,6 @@ ActiveRecord::Schema.define(version: 2019_01_12_044911) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "printfile_id"
-    t.index ["external_id"], name: "index_variants_on_external_id", unique: true
     t.index ["printfile_id"], name: "index_variants_on_printfile_id"
     t.index ["product_id"], name: "index_variants_on_product_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_12_034219) do
+ActiveRecord::Schema.define(version: 2019_01_12_035508) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,12 +66,10 @@ ActiveRecord::Schema.define(version: 2019_01_12_034219) do
   end
 
   create_table "products", force: :cascade do |t|
-    t.integer "external_id"
     t.string "title"
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["external_id"], name: "index_products_on_external_id", unique: true
   end
 
   create_table "purchase_orders", force: :cascade do |t|

--- a/db/seed_data.yml
+++ b/db/seed_data.yml
@@ -25,83 +25,115 @@ products:
       - fulfiller: printful
         external_id: 71
     variants:
-      - external_id: 9527
-        color: Black
+      - color: Black
         size: XS
         price: 25.00
-        printfile: t-shirt
-      - external_id: 4016
-        color: Black
+        fulfiller_variants:
+          - fulfiller: printful
+            external_id: 9527
+            printfile: t-shirt
+      - color: Black
         size: S
         price: 25.00
-        printfile: t-shirt
-      - external_id: 4017
-        color: Black
+        fulfiller_variants:
+          - fulfiller: printful
+            external_id: 4016
+            printfile: t-shirt
+      - color: Black
         size: M
         price: 25.00
-        printfile: t-shirt
-      - external_id: 4018
-        color: Black
+        fulfiller_variants:
+          - fulfiller: printful
+            external_id: 4017
+            printfile: t-shirt
+      - color: Black
         size: L
         price: 25.00
-        printfile: t-shirt
-      - external_id: 4019
-        color: Black
+        fulfiller_variants:
+          - fulfiller: printful
+            external_id: 4018
+            printfile: t-shirt
+      - color: Black
         size: XL
         price: 25.00
-        printfile: t-shirt
-      - external_id: 4020
-        color: Black
+        fulfiller_variants:
+          - fulfiller: printful
+            external_id: 4019
+            printfile: t-shirt
+      - color: Black
         size: 2XL
         price: 25.00
-        printfile: t-shirt
-      - external_id: 5295
-        color: Black
+        fulfiller_variants:
+          - fulfiller: printful
+            external_id: 4020
+            printfile: t-shirt
+      - color: Black
         size: 3XL
         price: 25.00
-        printfile: t-shirt
-      - external_id: 5310
-        color: Black
+        fulfiller_variants:
+          - fulfiller: printful
+            external_id: 5295
+            printfile: t-shirt
+      - color: Black
         size: 4XL
         price: 25.00
-        printfile: t-shirt
-      - external_id: 9526
-        color: White
+        fulfiller_variants:
+          - fulfiller: printful
+            external_id: 5310
+            printfile: t-shirt
+      - color: White
         size: XS
         price: 25.00
-        printfile: t-shirt
-      - external_id: 4011
-        color: White
+        fulfiller_variants:
+          - fulfiller: printful
+            external_id: 9526
+            printfile: t-shirt
+      - color: White
         size: S
         price: 25.00
-        printfile: t-shirt
-      - external_id: 4012
-        color: White
+        fulfiller_variants:
+          - fulfiller: printful
+            external_id: 4011
+            printfile: t-shirt
+      - color: White
         size: M
         price: 25.00
-        printfile: t-shirt
-      - external_id: 4013
-        color: White
+        fulfiller_variants:
+          - fulfiller: printful
+            external_id: 4012
+            printfile: t-shirt
+      - color: White
         size: L
         price: 25.00
-        printfile: t-shirt
-      - external_id: 4014
-        color: White
+        fulfiller_variants:
+          - fulfiller: printful
+            external_id: 4013
+            printfile: t-shirt
+      - color: White
         size: XL
         price: 25.00
-        printfile: t-shirt
-      - external_id: 4015
-        color: White
+        fulfiller_variants:
+          - fulfiller: printful
+            external_id: 4014
+            printfile: t-shirt
+      - color: White
         size: 2XL
         price: 25.00
-        printfile: t-shirt
-      - external_id: 5294
-        color: White
+        fulfiller_variants:
+          - fulfiller: printful
+            external_id: 4015
+            printfile: t-shirt
+      - color: White
         size: 3XL
         price: 25.00
-        printfile: t-shirt
-      - external_id: 5309
-        color: White
+        fulfiller_variants:
+          - fulfiller: printful
+            external_id: 5294
+            printfile: t-shirt
+      - color: White
         size: 4XL
         price: 25.00
-        printfile: t-shirt
+        fulfiller_variants:
+          - fulfiller: printful
+            external_id: 5309
+            printfile: t-shirt

--- a/db/seed_data.yml
+++ b/db/seed_data.yml
@@ -1,5 +1,9 @@
 # Seed data
 ---
+fulfillers:
+  printful:
+    name: Printful
+
 printfiles:
   t-shirt:
     width: 1800
@@ -8,7 +12,6 @@ printfiles:
 
 products:
   t-shirt:
-    external_id: 71
     title: Unisex T-Shirt
     description:
       |
@@ -18,6 +21,9 @@ products:
         - Fabric weight: 4.2 oz (142 g/m2)
         - Shoulder-to-shoulder taping
         - Side-seamed
+    fulfiller_products:
+      - fulfiller: printful
+        external_id: 71
     variants:
       - external_id: 9527
         color: Black

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,6 +8,10 @@
 
 DatabaseCleaner.clean_with(:truncation) unless Rails.env.production?
 
+def parse_fulfiller_data(data)
+  fulfiller_attributes = %w(name).map { |a| [a.to_sym, data[a]] }.to_h
+  Fulfiller.new(fulfiller_attributes)
+end
 
 def parse_printfile_data(data)
   printfile_attributes = %w(width height dpi).map { |a| [a.to_sym, data[a]] }.to_h
@@ -15,8 +19,14 @@ def parse_printfile_data(data)
 end
 
 def parse_product_data(data)
-  product_attributes = %w(external_id title description).map { |a| [a.to_sym, data[a]] }.to_h
+  product_attributes = %w(title description).map { |a| [a.to_sym, data[a]] }.to_h
   Product.new(product_attributes)
+end
+
+def parse_fulfiller_product_data(data, fulfillers)
+  fulfiller_product_attributes = %w(external_id).map { |a| [a.to_sym, data[a]] }.to_h
+  fulfiller_product_attributes[:fulfiller] = fulfillers.fetch(data['fulfiller'])
+  FulfillerProduct.new(fulfiller_product_attributes)
 end
 
 def parse_variant_data(data, printfiles)
@@ -26,6 +36,13 @@ def parse_variant_data(data, printfiles)
 end
 
 seeds = YAML.load_file('./db/seed_data.yml')
+
+fulfillers = {}
+seeds['fulfillers'].each do |key, fulfiller_data|
+  fulfiller = parse_fulfiller_data(fulfiller_data)
+  fulfiller.save!
+  fulfillers[key] = fulfiller
+end
 
 printfiles = {}
 seeds['printfiles'].each do |key, printfile_data|
@@ -37,6 +54,13 @@ end
 seeds['products'].each do |key, product_data|
   product = parse_product_data(product_data)
   product.save!
+
+  product_data['fulfiller_products'].each do |fulfiller_product_data|
+    fulfiller_product = parse_fulfiller_product_data(fulfiller_product_data, fulfillers)
+    fulfiller_product.product = product
+    fulfiller_product.save!
+  end
+
   product_data['variants'].each do |variant_data|
     variant = parse_variant_data(variant_data, printfiles)
     variant.product = product

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :product do
-    external_id { Faker::Number.number(4) }
     title { "Unisex T-Shirt" }
     description { Faker::Lorem.sentence }
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -11,7 +11,6 @@ FactoryBot.define do
   end
 
   factory :variant do
-    external_id { Faker::Number.number(4) }
     product
     color { Faker::Color.color_name.capitalize }
     size { %w[XS S M L XL 2XL 3XL 4XL].sample }


### PR DESCRIPTION
- Remove printful related information from Product and Variant models.
- Introduce fulfiller specific FulfillerProduct and FulfillerVariant models.

This is the first step in decoupling us from printful and allows us to support multiple fulfillers in the future.