### PR TITLE
Fix wordcloud links

### DIFF
--- a/app/javascript/components/WordCloud.js
+++ b/app/javascript/components/WordCloud.js
@@ -38,7 +38,10 @@ const WordCloud = ({ words }) => {
   return (
     <WordContainer>
       {words.map(word => (
-        <a key={word} href={`/design?text=${encodeURIComponent(word)}`}>
+        <a
+          key={word}
+          href={`/design?text=${encodeURIComponent(word).replace(/%20/g, "+")}`}
+        >
           <SupremeText>{word}</SupremeText>
         </a>
       ))}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4349,10 +4349,15 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.5, lodash@~4.17.10:
+lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.5, lodash@~4.17.10:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+
+lodash@^4.17.11:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 loglevel@^1.6.1:
   version "1.6.1"


### PR DESCRIPTION
Replace spaces with + signs so links in the word cloud point to `/design?text=Hello+World` and match the link from the design form.